### PR TITLE
Remove cache_valid_time

### DIFF
--- a/ansible/roles/autoware/tasks/main.yml
+++ b/ansible/roles/autoware/tasks/main.yml
@@ -12,10 +12,9 @@
       - python-pip
     state: latest
     update_cache: yes
-    cache_valid_time: 3600
   become: yes
 
-- name: Autoware (install gdown to download some files for neural network)    
+- name: Autoware (install gdown to download some files for neural network)
   pip:
     name:
       - gdown

--- a/ansible/roles/cuda/tasks/main.yml
+++ b/ansible/roles/cuda/tasks/main.yml
@@ -14,7 +14,6 @@
   apt:
     name: cuda-10-2
     update_cache: yes
-    cache_valid_time: 3600
 
 - name: CUDA (add path >> bashrc)
   lineinfile:

--- a/ansible/roles/lanelet2/tasks/main.yml
+++ b/ansible/roles/lanelet2/tasks/main.yml
@@ -11,7 +11,6 @@
       - python-catkin-tools
     state: latest
     update_cache: yes
-    cache_valid_time: 3600
   become: yes
 
 - name: Lanelet2 (clone Lanelet2 repository catkin workspace)

--- a/ansible/roles/ros/tasks/main.yml
+++ b/ansible/roles/ros/tasks/main.yml
@@ -17,7 +17,6 @@
     name: "ros-{{ release }}-{{ package }}"
     state: latest
     update_cache: yes
-    cache_valid_time: 3600
   become: yes
 
 - name: ROS (check rosdep file)
@@ -30,7 +29,6 @@
     name: "python-rosdep"
     state: latest
     update_cache: yes
-    cache_valid_time: 3600
   become: yes
 
 - name: ROS (initilize rosdep)
@@ -58,5 +56,4 @@
       - build-essential
     state: latest
     update_cache: yes
-    cache_valid_time: 3600
   become: yes

--- a/ansible/roles/tensorrt/tasks/main.yml
+++ b/ansible/roles/tensorrt/tasks/main.yml
@@ -18,7 +18,6 @@
       - libnvparsers7=7.0.0-1+cuda10.2
       - libnvparsers-dev=7.0.0-1+cuda10.2
     update_cache: yes
-    cache_valid_time: 3600
 
 - name: TensorRT (prevent cuda related packages from upgrading)
   become: yes


### PR DESCRIPTION
I've checked with the docker environment that `cache_valid_time` doesn't work for `cuda-10-2`.  
I'm sorry, but I'd like to revert all parts just in case.