### PR TITLE
Hotfix/lane change bug

### DIFF
--- a/src/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/route_handler.h
+++ b/src/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/include/lane_change_planner/route_handler.h
@@ -86,7 +86,7 @@ public:
   bool isDeadEndLanelet(const lanelet::ConstLanelet & lanelet) const;
   bool isInTargetLane(
     const geometry_msgs::PoseStamped & pose, const lanelet::ConstLanelets & target) const;
-
+  bool isInGoalRouteSection(const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getRouteLanelets() const;
   lanelet::ConstLanelets getLaneletSequence(const lanelet::ConstLanelet & lanelet) const;
   lanelet::ConstLanelets getLaneletSequence(

--- a/src/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/following_lane.cpp
+++ b/src/planning/scenario_planning/lane_driving/behavior_planning/lane_change_planner/src/state/following_lane.cpp
@@ -127,7 +127,7 @@ State FollowingLaneState::getNextState() const
   if (route_handler_ptr_->isInPreferredLane(current_pose_) && isLaneBlocked(current_lanes_)) {
     return State::BLOCKED_BY_OBSTACLE;
   }
-  if (isLaneChangeAvailable() || laneChangeForcedByOperator()) {
+  if (isLaneChangeAvailable() && laneChangeForcedByOperator()) {
     return State::FORCING_LANE_CHANGE;
   }
   if (isLaneChangeReady() && isLaneChangeApproved()) {


### PR DESCRIPTION
This PR fixes following bugs in lane change planner:

## Changes made
1. State transition from FollowingLane to ChangingLane
  - before: it changes lane without approval from operator
  - after: it changes lane after approval

2. Surpassing goal when vehicle cannot change lane to goal lane.
  - before: If goal is in right or left lane and if vehicle cannot change lane due to obstacles, vehicle will surpass goal pose.
  - after: Vehicle will wait before goal until the goal lane is clear of obstacle. 