### PR TITLE
Commented out directory non-existing directory

### DIFF
--- a/src/vehicle/as/CMakeLists.txt
+++ b/src/vehicle/as/CMakeLists.txt
@@ -62,6 +62,6 @@ install(TARGETS pacmod_interface
 install(
   DIRECTORY
     launch
-    data
+#    data
   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
 )


### PR DESCRIPTION
The `as` package couldn't be installed (`colcon` requires that packages are installable) because the `data` directory in the `install()` command does not exist.