### PR TITLE
Update ROS1->ROS2 porting docs

### DIFF
--- a/docs/porting-to-ROS2.md
+++ b/docs/porting-to-ROS2.md
@@ -94,6 +94,10 @@ By contrast, the `GenericTimer` provides an interface to supply a clock, but the
       this->get_node_base_interface()->get_context());
     this->get_node_timers_interface()->add_timer(timer_, nullptr);
 
+Also, this doesn't work, even with a subsequent `add_timer()` call:
+
+    timer_ = rclcpp::create_timer(this, this->get_clock(), period, timer_callback);
+
 
 #### Rosbag recording
 Unfortunately, one additional problem remains. `ros2 bag` does not record `/clock` (aka sim time) whereas `rosbag` does. This implies that in order to get the same behavior in ROS 2, either:

--- a/docs/porting-to-ROS2.md
+++ b/docs/porting-to-ROS2.md
@@ -1,46 +1,138 @@
 Porting ROS1 code to ROS2
 =======================
 
-# Frederik porting `shift_decider`
-
 ## Setting up the environment
+Make sure you have an empty `.adehome` file in `~/ade-home`, then clone [`AutowareArchitectureProposal`](https://github.com/tier4/AutowareArchitectureProposal) into that directory.
+
+There is an ADE environment with ROS Foxy from AutowareAuto. In the root directory of the repo, put an `.aderc` file with the following contents:
+
+    export ADE_DOCKER_RUN_ARGS="--cap-add=SYS_PTRACE -e RMW_IMPLEMENTATION=rmw_cyclonedds_cpp"
+    export ADE_GITLAB=gitlab.com
+    export ADE_REGISTRY=registry.gitlab.com
+    export ADE_DISABLE_NVIDIA_DOCKER=true
+    export ADE_IMAGES="
+      registry.gitlab.com/autowarefoundation/autoware.auto/autowareauto/amd64/ade-foxy:master
+    "
+
+Then start it:
+
+    cd ~/ade-home/AutowareArchitectureProposal
+    git checkout ros2
+    ade start --enter
+
+All commands that follow are to be entered in ADE. Next step is to fetch the sub-repos:
+
+    cd ~/AutowareArchitectureProposal
+    vcs import < autoware.proj.repos
+
+For instance, the `shift_decider` package is in the repository `github.com:tier4/pilot.auto.git`, which is now in the `autoware/pilot.auto` subdirectory.
+
+Now branch off `ros2` inside that subdirectory and delete the `COLCON_IGNORE` file in the package you want to port.
+
+The best source on migrating is the [migration guide](https://index.ros.org/doc/ros2/Contributing/Migration-Guide/), but some important changes are:
 
 
-I use the Autoware.Auto ADE with ros dashing to pull in all dependencies of 
-https://github.com/tier4/AutowareArchitectureProposal
-
-    cd ~/ade-home/
-    cd AutowareAuto
-    git checkout master
-    ade start  --enter
-
-**All commands that follow are to be entered in ADE!**
-
-Checkout the `AutowareArchitectureProposal` repo and start with the master branch
-
-    mkdir -p src
-    vcs import src < autoware.proj.repos
-
-Now the repository `github.com:tier4/autoware.iv.universe.git` that contains `shift_decider` is there   
-
-    cd src/
-    grep -R shift_decider
-
-Now create a new branch for the port to be merged in the upstream `ros2` branch and start porting!
+## Rewriting package.xml
+The migration guide covers this well. See also [here](https://www.ros.org/reps/rep-0149.html) for a reference of the most recent version of this format.
 
 
-## Tools to help porting
+## Rewriting CMakeLists.txt
+Pretty straightforward by following the example of the already ported `simple_planning_simulator` package and the [pub-sub tutorial](https://index.ros.org/doc/ros2/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber/#cpppubsub). Better yet, use `ament_auto` to get terse `CMakeLists.txt` that do not have as much redundancy with `package.xml` as an explicit `CMakeLists.txt`. See [this commit](https://github.com/tier4/Pilot.Auto/pull/7/commits/ef382a9b430fd69cb0a0f7ca57016d66ed7ef29d) for an example.
 
-### ros2-migration-tools
-Following the instructions at https://github.com/awslabs/ros2-migration-tools
+
+## ROS -> RCLCPP
+Search-and-replace "ros" with "rclcpp" and adjust everything that needs adjusting. From here on you can iteratively run `colcon build --packages-up-to vehicle_cmd_gate` and fix the first compiler error.
+
+
+## Replacing std_msgs
+In ROS2, you should define semantically meaningful wrappers around primitive (number) types.
+
+
+## Changing the namespaces and header files for generated message types
+An additional `::msg` needed to be inserted between the package namespace and the class name.
+
+The included headers similarly had to touched up with an extra `/msg` in the path and needed to be converted to `snake_case` – Sublime Text has a handy "Case Conversion" package for that. Unfortunately that gave a pretty cryptic error. Turns out _two_ files are being generated: One for C types (`.h` headers) and and one for CPP types (`.hpp` headers). So don't forget to change `.h` to `.hpp` too.
+
+
+## Inheriting from Node instead of NodeHandle members
+That's where differences start to show – I decided to make the `VehicleCmdGate` a `Node` even though the filename would suggest that `vehicle_cmd_gate_node.cpp` would be it. That's because it has publishers, subscribers, and logging. It previously had _two_ NodeHandles, a public one and a private one (`"~"`). The public one was unused and could be removed. Private nodes are not supported in ROS2, so I simply made it public, but that is an area that needs to be brought up in review.
+
+
+## Latched topics
+For each latched publisher, I just used `transient_local` QoS on the publisher, and we will need to do the same on all subscribers to that topic.
+
+
+## Timing issues
+One tricky item is `ros::Timer`. First, if the timer can be replaced with a data-driven pattern, it is [the preferred alternative for the long term](https://github.com/tier4/Pilot.Auto/pull/3#issuecomment-706732396).
+
+Assuming you still want to replicate the existing `ros::Timer` functionality: There is `rclcpp::WallTimer`, but it doesn't allow for using the `/clock` topic. That means it's not equivalent, i.e. the timer doesn't stop when simulation time stops. You can, however, use the following:
+
+    auto timer_callback = std::bind(&MyClass::timer_callback, this);
+    auto period = std::chrono::duration_cast<std::chrono::nanoseconds>(
+      std::chrono::duration<double>(update_period_));
+    timer_ = std::make_shared<rclcpp::GenericTimer<decltype(timer_callback)>>(
+      this->get_clock(), period, std::move(timer_callback),
+      this->get_node_base_interface()->get_context());
+    this->get_node_timers_interface()->add_timer(timer_, nullptr);
+
+Note that the callback does not receive `const ros::TimerEvent &` anymore.
+
+
+## Parameters
+It's not strictly necessary, but you probably want to make sure the filename is `xyz.param.yaml`. Then come two steps:
+
+
+### Adjust code
+    double vel_lim;
+    pnh_.param<double>("vel_lim", vel_lim, 25.0);
+
+becomes
+
+    const double vel_lim = declare_parameter("vel_lim", 25.0);
+
+which is equivalent to
+
+    const double vel_lim = declare_parameter<double>("vel_lim", 25.0);
+
+
+## Adjust param file
+Two levels of hierarchy need to be added around the parameters themselves:
+
+    <node name or /**>:
+      ros__parameters:
+        <params>
+
+Also, ROS1 didn't have a problem when you specify an integer, e.g. `28` for a `double` parameter, but ROS2 does:
+
+    [vehicle_cmd_gate-1] terminate called after throwing an instance of 'rclcpp::exceptions::InvalidParameterTypeException'
+    [vehicle_cmd_gate-1]   what():  parameter 'vel_lim' has invalid type: expected [double] got [integer]
+
+Best to just change `28` to `28.0` in the param file. See also [this issue](https://github.com/ros2/rclcpp/issues/979).
+
+
+## Launch file
+There is a [migration guide](https://index.ros.org/doc/ros2/Tutorials/Launch-files-migration-guide/). One thing it doesn't mention is that the `.launch` file also needs to be renamed to `.launch.xml`.
+
+
+## Replacing tf2_ros::Buffer
+A `tf2_ros::Buffer` member that is filled by a `tf2_ros::TransformListener` can become a `tf2::BufferCore` instead.
+BufferCore https://github.com/tier4/Pilot.Auto/pull/11
+
+
+
+
+
+## Alternative: Semi-automated porting with ros2-migration-tools (not working yet)
+Following the instructions at https://github.com/awslabs/ros2-migration-tools:
+
     pip3 install parse_cmake
     git clone https://github.com/awslabs/ros2-migration-tools.git
     wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-    tar xaf clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz 
+    tar xaf clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz
     cp -r clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04/lib/libclang.so ros2-migration-tools/clang/
     cp -r clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04/lib/libclang.so.10 ros2-migration-tools/clang/
     cp -r clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04/include/ ros2-migration-tools/clang/clang
-    
+
 The package needs to be **built with ROS1**. I followed http://wiki.ros.org/noetic/Installation/Ubuntu outside of ADE
 
     sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list'
@@ -68,71 +160,3 @@ Invoking "cmake" failed
 ```
 According to an expert:
 >  You should be able to compile it with colcon, cause it works for both ROS 1 and ROS 2 code. You are getting the same error with catkin so it's probably something related to ROS 1 and the build instructions.
-
-# Nikolai porting `vehicle_cmd_gate`
-
-The basic setup is the same as Fred, I also used the AutowareAuto ADE.
-
-The best source on migrating is the [migration guide](https://index.ros.org/doc/ros2/Contributing/Migration-Guide/), but the steps I followed are:
-
-## Copying the ROS1 code
-Branch off `ros2` and `git checkout control/vehicle_cmd_gate`.
-
-## Rewriting package.xml
-The migration guide covers this well. See [here](https://www.ros.org/reps/rep-0149.html) for a reference of the most recent version of this format.
-
-## Rewriting CMakeLists.txt
-Pretty straightforward by following the example of the already ported `simple_planning_simulator` package and the [pub-sub tutorial](https://index.ros.org/doc/ros2/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber/#cpppubsub).
-
-## ROS -> RCLCPP
-Search-and-replace "ros" with "rclcpp" and adjust everything that needs adjusting. From here on I constantly ran `colcon build --packages-up-to vehicle_cmd_gate` and looked at the first error.
-
-## Replacing std_msgs
-ROS2 forces you to define semantically meaningful wrappers around primitive (number) types. It was luckily pretty clear which package they should belong to.
-
-## Changing the namespaces and header files for generated message types
-An additional `::msg` needed to be inserted between the package namespace and the class name.
-
-The included headers similarly had to touched up with an extra `/msg` in the path and needed to be converted to `snake_case` – Sublime Text has a handy "Case Conversion" package for that. Unfortunately that gave a pretty cryptic error. Turns out _two_ files are being generated: One for C types (`.h` headers) and and one for CPP types (`.hpp` headers). So don't forget to change `.h` to `.hpp` too.
-
-## Inheriting from Node instead of NodeHandle members
-That's where differences start to show – I decided to make the `VehicleCmdGate` a `Node` even though the filename would suggest that `vehicle_cmd_gate_node.cpp` would be it. That's because it has publishers, subscribers, and logging. It previously had _two_ NodeHandles, a public one and a private one (`"~"`). The public one was unused and could be removed. Private nodes are not supported in ROS2, so I simply made it public, but that is an area that needs to be brought up in review.
-
-## Latched topics
-For each latched publisher, I just used `transient_local` QoS on the publisher, and we will need to do the same on all subscribers to that topic.
-
-## Timing issues
-The differences didn't matter here so much. The only thing I'm not so sure about is how to port a `ros::Timer`. In my understanding, `rclcpp::WallTimer` doesn't allow for using the `/clock` topic so it's not equivalent, i.e. the timer doesn't stop when simulation time stops.
-
-## Parameters
-It's not strictly necessary, but you probably want to make sure the filename is `xyz.param.yaml`. Then come two steps:
-
-### Adjust code
-    double vel_lim;
-    pnh_.param<double>("vel_lim", vel_lim, 25.0);
-
-becomes
-
-    const double vel_lim = declare_parameter("vel_lim", 25.0);
-
-which is equivalent to
-
-    const double vel_lim = declare_parameter<double>("vel_lim", 25.0);
-
-## Adjust param file
-Two levels of hierarchy need to be added around the parameters themselves:
-
-    <node name or /**>:
-      ros__parameters:
-        <params>
-
-Also, ROS1 didn't have a problem when you specify an integer, e.g. `28` for a `double` parameter, but ROS2 does:
-
-    [vehicle_cmd_gate-1] terminate called after throwing an instance of 'rclcpp::exceptions::InvalidParameterTypeException'
-    [vehicle_cmd_gate-1]   what():  parameter 'vel_lim' has invalid type: expected [double] got [integer]
-
-Best to just change `28` to `28.0` in the param file. See also [this issue](https://github.com/ros2/rclcpp/issues/979).
-
-
-## Launch file
-There is a [migration guide](https://index.ros.org/doc/ros2/Tutorials/Launch-files-migration-guide/). One thing it doesn't mention is that the `.launch` file also needs to be renamed to `.launch.xml`.

--- a/docs/porting-to-ROS2.md
+++ b/docs/porting-to-ROS2.md
@@ -44,17 +44,18 @@ The migration guide covers this well. See also [here](https://www.ros.org/reps/r
 Pretty straightforward by following the example of the already ported `simple_planning_simulator` package and the [pub-sub tutorial](https://index.ros.org/doc/ros2/Tutorials/Writing-A-Simple-Cpp-Publisher-And-Subscriber/#cpppubsub). Better yet, use `ament_auto` to get terse `CMakeLists.txt` that do not have as much redundancy with `package.xml` as an explicit `CMakeLists.txt`. See [this commit](https://github.com/tier4/Pilot.Auto/pull/7/commits/ef382a9b430fd69cb0a0f7ca57016d66ed7ef29d) for an example.
 
 
-## Replacing `std_msgs`
+### Replacing `std_msgs`
 In ROS2, you should define semantically meaningful wrappers around primitive (number) types.
 
 
-## Changing the namespaces and header files for generated message types
-An additional `::msg` needed to be inserted between the package namespace and the class name.
+### Changing the namespaces and header files for generated message types
 
-The included headers similarly had to touched up with an extra `/msg` in the path and needed to be converted to `snake_case` – Sublime Text has a handy "Case Conversion" package for that. Unfortunately that gave a pretty cryptic error. Turns out _two_ files are being generated: One for C types (`.h` headers) and and one for CPP types (`.hpp` headers). So don't forget to change `.h` to `.hpp` too.
+If you follow the migration guide and change the included headers to have an extra `/msg` in the path and convert to `snake_case`, you might get a cryptic error. Turns out _two_ files are being generated: One for C types (`.h` headers) and and one for CPP types (`.hpp` headers). So don't forget to change `.h` to `.hpp` too. Also, don't forget to insert an additional `::msg` between the package namespace and the class name.
+
+A tip: Sublime Text has a handy "Case Conversion" package for converting to snake case.
 
 
-## Inheriting from Node instead of NodeHandle members
+### Inheriting from Node instead of NodeHandle members
 That's where differences start to show – I decided to make the `VehicleCmdGate` a `Node` even though the filename would suggest that `vehicle_cmd_gate_node.cpp` would be it. That's because it has publishers, subscribers, and logging. It previously had _two_ NodeHandles, a public one and a private one (`"~"`). The public one was unused and could be removed. Private nodes are not supported in ROS2, so I simply made it public, but that is an area that needs to be brought up in review.
 
 


### PR DESCRIPTION
* Restructuring so that it's less about Fred's and my personal experiences and more of a guide
* Added `GenericTimer` workaround and best practices from https://github.com/tier4/Pilot.Auto/pull/3#issuecomment-706732396
* Added `tf2_ros::Buffer` section

