### PR TITLE
Remove osqp-vendor from autoware.proj.repos

### DIFF
--- a/autoware.proj.repos
+++ b/autoware.proj.repos
@@ -34,11 +34,6 @@ repositories:
     type: git
     url: https://github.com/tier4/scenario_runner.iv.universe.git
     version: ros2
-  vendor/osqp:
-    type: git
-    url: https://github.com/tier4/osqp_vendor.git
-    version: main
-  # vendor
 #  vendor/lanelet2:
 #    type: git
 #    url: https://github.com/fzi-forschungszentrum-informatik/Lanelet2.git


### PR DESCRIPTION
@esteve That's we get for trying to speed things up. The osqp_vendor package appeared twice when installing the dependencies from `autoware.proj.repos` 

Easy to fix 

fixes #89. @dejanpan
