### PR TITLE
Vendor geometry2 repo

### DIFF
--- a/autoware.proj.repos
+++ b/autoware.proj.repos
@@ -43,6 +43,10 @@ repositories:
     type: git
     url: https://github.com/tier4/ublox.git
     version: foxy-devel
+  vendor/geometry2:
+    type: git
+    url: https://github.com/ros2/geometry2.git
+    version: foxy
 #  vendor/lanelet2:
 #    type: git
 #    url: https://github.com/fzi-forschungszentrum-informatik/Lanelet2.git


### PR DESCRIPTION
This temporarily (~2 weeks) pulls in the `foxy` branch of the `geometry2` repo which has a new overload of `tf2::doTransform` for the `PoseWithCovarianceStamped` type.

I tested that packages from this repo are shadowing packages from the ROS install.
