### PR TITLE
Remove vendored geometry2 repo

### DIFF
--- a/autoware.proj.repos
+++ b/autoware.proj.repos
@@ -43,10 +43,6 @@ repositories:
     type: git
     url: https://github.com/tier4/ublox.git
     version: foxy-devel
-  vendor/geometry2:
-    type: git
-    url: https://github.com/ros2/geometry2.git
-    version: foxy
 #  vendor/lanelet2:
 #    type: git
 #    url: https://github.com/fzi-forschungszentrum-informatik/Lanelet2.git


### PR DESCRIPTION
https://github.com/ros/rosdistro/pull/27177 is now available through the ROS package repositories: I upgraded my system in ADE today and got 

```
$ apt show ros-foxy-tf2
Package: ros-foxy-tf2
Version: 0.13.6-1focal.20201028.172335
```

which is the version that has the PR required for `ndt_scan_matcher`.