### PR TITLE
Vendor topic_tools repository

### DIFF
--- a/autoware.proj.repos
+++ b/autoware.proj.repos
@@ -51,6 +51,14 @@ repositories:
     type: git
     url: https://github.com/ros-perception/perception_pcl.git
     version: foxy-devel
+  vendor/rclcpp_generic:
+    type: git
+    url: https://github.com/ApexAI/rclcpp_generic.git
+    version: dfcb031f53728311e439079ad61e2d59d525b17f
+  vendor/topic_tools:
+    type: git
+    url: https://github.com/ApexAI/topic_tools.git
+    version: 8fc11e5b7a8db42fbb13c47de9627424332b4fa7
 #  vendor/lanelet2:
 #    type: git
 #    url: https://github.com/fzi-forschungszentrum-informatik/Lanelet2.git


### PR DESCRIPTION
This temporarily pulls in the topic_tools package and its dependency rclcpp_generic to fix https://github.com/tier4/Pilot.Auto/issues/82. The versions are fixed so that there is no risk of accidentally breaking the build while those packages are further developed.