### PR TITLE
Add usb_cam dependency

### DIFF
--- a/autoware.proj.repos
+++ b/autoware.proj.repos
@@ -59,6 +59,11 @@ repositories:
     type: git
     url: https://github.com/mitsudome-r/diagnostics.git
     version: ros2-devel
+  vendor/usb_cam: # TODO remove after https://github.com/ros-drivers/usb_cam/pull/132 is available in foxy
+    type: git
+    url: https://github.com/flynneva/usb_cam.git
+    version: foxy
+
 #  vendor/lanelet2:
 #    type: git
 #    url: https://github.com/fzi-forschungszentrum-informatik/Lanelet2.git


### PR DESCRIPTION
In porting `sensing_launch` in this [PR](https://github.com/tier4/autoware_launcher.iv.universe/pull/14), I just stumbled over a dependency on `usb_cam`. Unfortunately there is no official ros2 version yet ([PR in progress](https://github.com/ros-drivers/usb_cam/pull/132)), so  for the time being, I add the branch as a dependency here and will open another PR to add it to `autoware_launcher` repo as well so its CI works

@esteve @mitsudome-r 
