### PR TITLE
Revise guideline about unit of throttle delay

### DIFF
--- a/docs/porting-to-ROS2.md
+++ b/docs/porting-to-ROS2.md
@@ -500,12 +500,9 @@ with the exception of
 +RCLCPP_WARN_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), duration, ...)
 ```
 
-where the `duration` is an integer interpreted as milliseconds. A readable way to formulate that is
+where the `duration` is an integer interpreted as milliseconds. A readable way to document that is
 
-    using namespace std::literals;
-    ...
-    static constexpr auto duration = (5000ms).count();
-    RCLCPP_WARN_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), duration, ...)
+    RCLCPP_WARN_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 5000 /* ms */, ...)
 
 
 ### Shutting down a subscriber

--- a/docs/porting-to-ROS2.md
+++ b/docs/porting-to-ROS2.md
@@ -500,7 +500,7 @@ with the exception of
 +RCLCPP_WARN_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), duration, ...)
 ```
 
-where the `duration` is an integer interpreted as milliseconds. A readable way to document that is
+where the `duration` is an integer interpreted as milliseconds as opposed to seconds in ROS1. A readable way to document that is
 
     RCLCPP_WARN_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 5000 /* ms */, ...)
 


### PR DESCRIPTION
This is a bit late, but if I look at the failure modes we want to protect against, I think we're better off with just a comment. Here are the failure modes I can think about, for a developer reading/modifying/copy-pasting this code:
* The developer comes from ROS1 and assumes durations are seconds => solved by both variants
* The developer doesn't know how `chrono` works (like myself not so long ago) and thinks that
  * `count()` converts into the right unit for them¹ => they'll try `(5s).count()`
  * `count()` returns some magic duration type that is needed here => not bad in itself, just confusing
* The developer doesn't know this is a duration => solved by both, although more explicitly with the variable


¹ It would be very reasonable to assume that it converts into the smallest unit, nanoseconds, which is also used everywhere in ROS2 except here