### PR TITLE
add livox ros2 in repos

### DIFF
--- a/autoware.proj.repos
+++ b/autoware.proj.repos
@@ -67,6 +67,10 @@ repositories:
     type: git
     url: https://github.com/tier4/tamagawa_imu_driver.git
     version: ros2
+  vendor/livox-driver:
+    type: git
+    url: https://github.com/fred-apex-ai/livox_ros2_driver.git
+    version: master
 
 #  vendor/lanelet2:
 #    type: git


### PR DESCRIPTION
## Related issue
#147 

## What this pr
Add livox ros2 driver in repos file since ./setup2004.sh fails

## How to review 
./setup2004.sh  works in ros2 branch