### PR TITLE
install vcstool and do vcs import in ansible setup

### DIFF
--- a/ansible/roles/autoware/tasks/main.yml
+++ b/ansible/roles/autoware/tasks/main.yml
@@ -1,4 +1,12 @@
 ---
+- name: Autoware (make directory)
+  file:
+    path: "{{ AUTOWARE_DIR }}/src"
+    state: directory
+
+- name: Autoware  (vcs import)
+  shell: vcs import {{ AUTOWARE_DIR }}/src < {{ AUTOWARE_DIR }}/autoware.proj.repos
+
 - name: Autoware (update rosdep)
   command: rosdep update
   become: yes

--- a/ansible/roles/ros2/tasks/main.yml
+++ b/ansible/roles/ros2/tasks/main.yml
@@ -69,3 +69,10 @@
     state: latest
     update_cache: yes
   become: yes
+
+- name: ROS2 (install vcstool)
+  apt:
+    name: "python3-vcstool"
+    state: latest
+    update_cache: yes
+  become: yes


### PR DESCRIPTION
## PRの種類

- [ ] 新機能
- [ ] 既存機能の性能向上
- [ ] バグフィックス

## Jiraリンク

## 変更概要
do following tasks in ansible
- install python3-vcstool 
- do vcs import 

## レビュー方法



## その他

- [ ] [リリースノート](https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416)への記載
