### PR TITLE
Add rosbag to .repos

### DIFF
--- a/autoware.proj.repos
+++ b/autoware.proj.repos
@@ -95,6 +95,10 @@ repositories:
     type: git
     url: https://github.com/tier4/rqt_runtime_monitor.git
     version: dashing-devel
+  vendor/rosbag: # TODO remove after https://github.com/ros2/rosbag2/pull/625 is released
+    type: git
+    url: https://github.com/ros2/rosbag2.git
+    version: emersonknapp/backport-latest-to-foxy
 # calibration
 #  calibration/tunable_static_tf_broadcaster:
 #    type: git


### PR DESCRIPTION
I've tested with these commands:

```sh
$ vcs import src < autoware.proj.repos
$ colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release
$ source install/setup.bash
$ ros2 pkg prefix rosbag2
/home/kenji/AutowareArchitectureProposal.proj/install/rosbag2
```