### PR TITLE
Separate Ansible tasks related to vcs import to new role

### DIFF
--- a/ansible/localhost-setup-ubuntu20.04-devpc.yml
+++ b/ansible/localhost-setup-ubuntu20.04-devpc.yml
@@ -13,10 +13,11 @@
         prompt: "[Warning]: Skip install GPU modules. Try manually installing these modules to execute nodes depending on TensorRT."
       when: yn_gpu != 'y'
   roles:
-    - { role: cuda, when: yn_gpu == 'y' }
-    - { role: tensorrt, when: yn_gpu == 'y' }
-    - { role: ros2, rosdistro: foxy }
-    - { role: autoware, rosdistro: foxy }
-    - { role: kvaser }  # Temporary for ros2 porting
-    # - { role: pacmod, rosdistro: foxy }  # Temporary for ros2 porting
-    # - { role: ros, release: melodic }
+    - { role: cuda, when: yn_gpu == 'y', tags: ["cuda"] }
+    - { role: tensorrt, when: yn_gpu == 'y', tags: ["tensorrt"] }
+    - { role: ros2, rosdistro: foxy, tags: ["ros2"] }
+    - { role: vcs, tags: ["vcs"] }
+    - { role: autoware, rosdistro: foxy, tags: ["autoware"] }
+    - { role: kvaser, tags: ["kvaser"] }  # Temporary for ros2 porting
+    # - { role: pacmod, rosdistro: foxy, tags: ["pacmod"] }  # Temporary for ros2 porting
+    # - { role: ros, release: melodic, tags: ["ros"] }

--- a/ansible/roles/autoware/tasks/main.yml
+++ b/ansible/roles/autoware/tasks/main.yml
@@ -1,12 +1,4 @@
 ---
-- name: Autoware (make directory)
-  file:
-    path: "{{ AUTOWARE_DIR }}/src"
-    state: directory
-
-- name: Autoware  (vcs import)
-  shell: vcs import {{ AUTOWARE_DIR }}/src < {{ AUTOWARE_DIR }}/autoware.proj.repos
-
 - name: Autoware (update rosdep)
   command: rosdep update
   become: yes

--- a/ansible/roles/ros2/tasks/main.yml
+++ b/ansible/roles/ros2/tasks/main.yml
@@ -69,3 +69,10 @@
     state: latest
     update_cache: yes
   become: yes
+
+- name: ROS2 (install vcstool)
+  apt:
+    name: "python3-vcstool"
+    state: latest
+    update_cache: yes
+  become: yes

--- a/ansible/roles/ros2/tasks/main.yml
+++ b/ansible/roles/ros2/tasks/main.yml
@@ -69,10 +69,3 @@
     state: latest
     update_cache: yes
   become: yes
-
-- name: ROS2 (install vcstool)
-  apt:
-    name: "python3-vcstool"
-    state: latest
-    update_cache: yes
-  become: yes

--- a/ansible/roles/vcs/tasks/main.yml
+++ b/ansible/roles/vcs/tasks/main.yml
@@ -1,0 +1,15 @@
+---
+- name: VCS (install vcstool)
+  apt:
+    name: "python3-vcstool"
+    state: latest
+    update_cache: yes
+  become: yes
+
+- name: VCS (make directory)
+  file:
+    path: "{{ AUTOWARE_DIR }}/src"
+    state: directory
+
+- name: VCS (vcs import)
+  shell: vcs import {{ AUTOWARE_DIR }}/src < {{ AUTOWARE_DIR }}/autoware.proj.repos

--- a/ansible/roles/vcs/tasks/main.yml
+++ b/ansible/roles/vcs/tasks/main.yml
@@ -1,11 +1,4 @@
 ---
-- name: VCS (install vcstool)
-  apt:
-    name: "python3-vcstool"
-    state: latest
-    update_cache: yes
-  become: yes
-
 - name: VCS (make directory)
   file:
     path: "{{ AUTOWARE_DIR }}/src"


### PR DESCRIPTION
To skip vcs import in CI environment, etc., I separated Ansible tasks related to vcs import to new role and added tags to roles.
