### PR TITLE
added scripts for use_sim_time management

### DIFF
--- a/scripts/add_aw_ros2_use_sim_time_into_launch_xml.pl
+++ b/scripts/add_aw_ros2_use_sim_time_into_launch_xml.pl
@@ -1,0 +1,31 @@
+#!/usr/bin/perl
+
+$use_sim_time_str='<param name="use_sim_time" value="$(env AW_ROS2_USE_SIM_TIME false)"/>' . "\n";
+
+$out_line="";
+while(<>){
+	if(/^(\s*)<\s*node\s/){
+		$indent=$1;
+		$out_line = $indent . "  " . $use_sim_time_str;
+		if(/\/\s*>\s*$/){
+			$re_str = quotemeta($&);
+			~s/$re_str/ >\n/;
+			print;
+			$out_line = $out_line . $indent . "</node>\n";
+			print $out_line;
+			$out_line = "";
+		}else{
+			print;
+		}
+	}elsif($out_line ne ""){
+		if(/^\s*<\s*param\s*name.*use_sim_time.*AW_ROS2_USE_SIM_TIME/){
+			$out_line = "";
+		}elsif(/^\s*<\s*\/\s*node\s*>\s*$/){
+			print $out_line;
+			$out_line = "";
+		}
+		print;
+	}else{
+		print;
+	}
+}

--- a/scripts/add_aw_ros2_use_sim_time_into_launch_xml.sh
+++ b/scripts/add_aw_ros2_use_sim_time_into_launch_xml.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+if [ -n "$1" ]; then
+	find_dir=$1
+else
+	echo "Usage: $0 <dir ('install' dir is recommended)>"
+	exit 0
+fi
+
+patch_script=$(dirname $(realpath $0))/$(basename $0 .sh).pl
+
+for xml in $(find $find_dir -type f | grep launch.xml$); do
+	echo "mv $xml ${xml}.org_tmp"
+	eval "mv $xml ${xml}.org_tmp"
+	echo "$patch_script ${xml}.org_tmp > $xml"
+	eval "$patch_script ${xml}.org_tmp > $xml"
+	echo "rm ${xml}.org_tmp"
+	eval "rm ${xml}.org_tmp"
+	echo ""
+done
+

--- a/scripts/get_use_sim_time_all.sh
+++ b/scripts/get_use_sim_time_all.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+( for node in $(ros2 run topic_tools node_list |& grep \/ | perl -pe "~s/^[^\/]\//\//")
+#for node in $(ros2 param list|grep :)
+do
+	#n=$(dirname $node)/$(basename $node :)
+	#echo "$n: use_sim_time: $(ros2 param get $n use_sim_time)"
+	echo "$node: use_sim_time: $(ros2 param get $node use_sim_time)"
+done) |& grep \/


### PR DESCRIPTION
## PRの種類
Added scripts to add AW_ROS2_USE_SIM_TIME settings recursively for each .launch.xml files in the directory as an argument 
Usage: ./scripts/add_aw_ros2_use_sim_time_into_launch_xml.sh <dir ('install' dir is recommended)>

And added script to check status of use_sim_time for each nodes.
Usage: ./scripts/get_use_sim_time_all.sh

- [ ] 新機能
- [ ] 既存機能の性能向上
- [ ] バグフィックス

## Jiraリンク

## 変更概要

## レビュー方法

## その他

- [ ] [リリースノート](https://tier4.atlassian.net/wiki/spaces/AIP/pages/563774416)への記載
