### PR TITLE
Fix typo in design documents

### DIFF
--- a/design/Control/TrajectoryFollower/LateralController.md
+++ b/design/Control/TrajectoryFollower/LateralController.md
@@ -2,7 +2,7 @@
 
 # Overview
 
-For following target trajectory, control stack needs to output lateral control commands (steering angle, steering angle velocty), and logitudinal control commands (acceleration, velocity). Lateral controller module is responsible for calculation of lateral control commands.
+For following target trajectory, control stack needs to output lateral control commands (steering angle, steering angle velocity), and longitudinal control commands (acceleration, velocity). Lateral controller module is responsible for calculation of lateral control commands.
 
 ## Role
 

--- a/design/Control/TrajectoryFollower/LongitudinalController.md
+++ b/design/Control/TrajectoryFollower/LongitudinalController.md
@@ -2,7 +2,7 @@
 
 # Overview
 
-For following target trajectory, control stack needs to output lateral control commands (steering angle, steering angle velocty), and logitudinal control commands (acceleration, velocity). Logitudinal controller module is responsible for calculation of logitudinal control commands.
+For following target trajectory, control stack needs to output lateral control commands (steering angle, steering angle velocity), and longitudinal control commands (acceleration, velocity). Longitudinal controller module is responsible for calculation of longitudinal control commands.
 
 ## Role
 

--- a/design/Control/VehicleCmdGate/VehicleCmdGate.md
+++ b/design/Control/VehicleCmdGate/VehicleCmdGate.md
@@ -9,7 +9,7 @@ Vehicle Cmd Gate module is responsible for Systematic post-processing.
 Roles of Vehicle Cmd Gate module are as follows.
 
 - Reshape the vehicle control command
-  - Vehicle Cmd Gate module convert `autoware_control_msgs/ControlCommandStamped` to `autoware_vehicle_msgs/VehicleCommand`. This conversion includes the addtion of gear shifting command.
+  - Vehicle Cmd Gate module convert `autoware_control_msgs/ControlCommandStamped` to `autoware_vehicle_msgs/VehicleCommand`. This conversion includes the addition of gear shifting command.
 - Reflect engage command to control signal for vehicles
   - Until true command is sent as engage command, Vehicle Cmd Gate module does not pass the input command information as output.
 - Select the command values (Trajectory follow command, Remote manual command)
@@ -46,4 +46,4 @@ The main inputs included in `autoware_vehicle_msgs/VehicleCommand` are as follow
 | Gear shifting command   | std_msgs/Int32   |
 | Emergency command       | std_msgs/Int32   |
 
-Note that most of above commands are ouput as 0 until true command is sent as engage command.
+Note that most of above commands are output as 0 until true command is sent as engage command.

--- a/design/Localization/PoseEstimator/PoseEstimator.md
+++ b/design/Localization/PoseEstimator/PoseEstimator.md
@@ -2,7 +2,7 @@ Pose Estimator
 ==============
 
 ### Role
-Pose estimator is a component to estimate ego vehicle pose which includes position and orientation. The final output should also include covariance, which represesents the estimator's confidence on estimated pose. A pose estimator could either be estimate pose on local map, or it can estimate absolute pose using global localizer. The output pose can be publihsed in any frame as long as /tf is provided to project into the "map" frame. Also, pose estimator should stop publishing pose if it is possible to calculate reliability of estimated pose(e.g. matching score with map) and the reliability is low.
+Pose estimator is a component to estimate ego vehicle pose which includes position and orientation. The final output should also include covariance, which represents the estimator's confidence on estimated pose. A pose estimator could either be estimate pose on local map, or it can estimate absolute pose using global localizer. The output pose can be published in any frame as long as /tf is provided to project into the "map" frame. Also, pose estimator should stop publishing pose if it is possible to calculate reliability of estimated pose(e.g. matching score with map) and the reliability is low.
 
 ## Input
 
@@ -25,7 +25,7 @@ Pose estimator is a component to estimate ego vehicle pose which includes positi
 This is a sample design of our implementation using NDT Scan Matcher. 
 ![Pose_Estimator](/design/img/PoseEstimator.svg)
 
-We integrated 3D NDT registration method for sample pose estimation algorithm. The NDT registration method is an local localization method that requires a good intial guess before optimizing pose. In order to realize fully automatic localization, GNSS is used for first initialization. After first loop of pose estimation, the output of pose twist fusion filter is used as next initial guess of NDT registration.
+We integrated 3D NDT registration method for sample pose estimation algorithm. The NDT registration method is a local localization method that requires a good initial guess before optimizing pose. In order to realize fully automatic localization, GNSS is used for first initialization. After first loop of pose estimation, the output of pose twist fusion filter is used as next initial guess of NDT registration.
 
 Note that NDT scan matcher does not publish pose when matching score calculated in alignment is less than threshold value to avoid publishing wrong estimated pose to Pose Twist Fusion Filter.
 

--- a/design/Map/Map.md
+++ b/design/Map/Map.md
@@ -10,11 +10,11 @@ Map is responsible for distributing static information about the environment tha
 ## Use Cases
 
 ### Pointcloud Map
-Uses cases of the maps are the following:
-* Localization: Autoware must always be aware of its position in Earth frame. Poincloud map is used for local localization with LiDAR based localization algorithm such as NDT matching.
+Use cases of the maps are the following:
+* Localization: Autoware must always be aware of its position in Earth frame. Pointcloud map is used for local localization with LiDAR based localization algorithm such as NDT matching.
 
 ### Vector Map
-Vector map provides sematinc information about roads and is used for various uses cases in both Planning and Perception. Note that some of the following use cases might be removed as performance of perception improves. For example, retrieving lane shapes and detecting traffic lights can be done online e.g. using camera images. However, with consideration of [spoofing attacks](https://www.nassiben.com/mobilbye) and reliablilty of current Perception stack, following uses cases must be supported by vector map for now.
+Vector map provides semantic information about roads and is used for various uses cases in both Planning and Perception. Note that some of the following use cases might be removed as performance of perception improves. For example, retrieving lane shapes and detecting traffic lights can be done online e.g. using camera images. However, with consideration of [spoofing attacks](https://www.nassiben.com/mobilbye) and reliability of current Perception stack, following uses cases must be supported by vector map for now.
 
 * Planning:
   * Calculating route from start to goal
@@ -29,15 +29,15 @@ Vector map provides sematinc information about roads and is used for various use
 The role of map is to publish map information to other stacks. In order to satisfy use cases above, the following requirements must be met.
 
 ### PointCloud map 
-  * The map should provide goemetric information of surrounding environment that includes any region 200m away from any possible route that the vehicle might take.
+  * The map should provide geometric information of surrounding environment that includes any region 200m away from any possible route that the vehicle might take.
   * Resolution of pointcloud map must be at least 0.2m. (from past experience)
-  * Size of the map should be less than 1GB in binary format. (Limit of ROS messsage)
+  * Size of the map should be less than 1GB in binary format. (Limit of ROS message)
   * Pointcloud must be georeferenced.
 
 ### Vector Map
   * The map should be georeferenced.
   * The map should include region within 200m away from any possible route that autonomous vehicle might drive with following information:
-    * Routing: the map should be able to retrieve next lane, previous lane, right lane, and left lane of a lane with availablility of lane change.
+    * Routing: the map should be able to retrieve next lane, previous lane, right lane, and left lane of a lane with availability of lane change.
     * Geometry: shape and position of following objects must be provided:
       * lanes
       * traffic lights

--- a/design/Map/SemanticMap/AutowareLanelet2Format.md
+++ b/design/Map/SemanticMap/AutowareLanelet2Format.md
@@ -6,7 +6,7 @@ In addition to default Lanelet2 Format, users should add following mandatory/opt
 
 ## Additional Conventions
 ### Lane length
-Original Lanelet2 format does not specify the minimum or maximum length of lane. However, without the limit, it is very difficult to extimate memory size and computation time using lane information. Therefore, we set general convention that a lanelet should have length between 1m ~ 50m.
+Original Lanelet2 format does not specify the minimum or maximum length of lane. However, without the limit, it is very difficult to estimate memory size and computation time using lane information. Therefore, we set general convention that a lanelet should have length between 1m ~ 50m.
 
 ### No Self Crossing Lanes
 In order to make geometrical calculation of lane easier (e.g. getting drivable area, operating triangulation, etc) we set a convention that no lanes should overlap itself. Whenever, it overlaps itself, the lane should be separated into two different lanes with same attributes.
@@ -39,7 +39,7 @@ Here is an example osm syntax for a lanelet object.
 ```
 
 ### TrafficLights
-Default Lanelet2 format uses LineString(`way`) or Polygon class to represent the shape of a traffic light. For Autoware, traffic light objects must be represented only by LineString to avoid confusion, where start point is at bottom left edge and end point is at bottom right edge. Also, "height" tag must be added in order to represent the size in verticle direction(not the position). 
+Default Lanelet2 format uses LineString(`way`) or Polygon class to represent the shape of a traffic light. For Autoware, traffic light objects must be represented only by LineString to avoid confusion, where start point is at bottom left edge and end point is at bottom right edge. Also, "height" tag must be added in order to represent the size in vertical direction(not the position). 
 
 The Following image illustrates how LineString is used to represent shape of Traffic Light in Autoware.
 <img src="./docs/traffic_light.png" width="600">
@@ -56,7 +56,7 @@ Here is an example osm syntax for traffic light object.
 </way>
 ```
 
-### Turn Diretions
+### Turn Directions
 Users must add "turn_direction" tags to lanelets within intersections to indicate vehicle's turning direction. You do not need this tags for lanelets that are not in intersections. If you do not have this tag, Autoware will not be able to light up turning indicators. 
 This tags only take following values:
 * left
@@ -67,7 +67,7 @@ Following image illustrates how lanelets should be tagged.
 
 <img src="./docs/turn_direction.png" width="600">
 
-Here is an example of osm sytax for lanelets in intersections. 
+Here is an example of osm syntax for lanelets in intersections. 
 ```
 <relation id='1' visible='true' version='1'>
   <member type='way' ref='2' role='left' />
@@ -85,7 +85,7 @@ Here is an example of osm sytax for lanelets in intersections.
 Following tags are optional tags that you may want to add depending on how you want to use your map in Autoware. 
 
 ### Meta Info
-Users may add the `MetaInfo` element to their OSM file to indicate format version and map version of their OSM file. This information is not meant to influence Autoware vehicle's behavior, but is published as ROS message so that developers could know which map was used from ROSBAG log files. MetaInfo elements exists in the same hiararchy with `node`, `way`, and `relation` elements, otherwise JOSM wouldn't be able to load the file correctly.
+Users may add the `MetaInfo` element to their OSM file to indicate format version and map version of their OSM file. This information is not meant to influence Autoware vehicle's behavior, but is published as ROS message so that developers could know which map was used from ROSBAG log files. MetaInfo elements exists in the same hierarchy with `node`, `way`, and `relation` elements, otherwise JOSM wouldn't be able to load the file correctly.
 
 Here is an example of MetaInfo in osm file:
 ```

--- a/design/Messages.md
+++ b/design/Messages.md
@@ -3,7 +3,7 @@ Messages
 
 # Overview
 
-In this section, it is descrived that 8 categories of messages in the architecture:
+In this section, it is described that 8 categories of messages in the architecture:
 
 - autoware control messages
 - autoware lanelet2 messages
@@ -14,7 +14,7 @@ In this section, it is descrived that 8 categories of messages in the architectu
 - autoware vector map messages
 - autoware vehicle messages
 
-the difinition of each message is shown in following subsection.
+the definition of each message is shown in following subsection.
 
 ## autoware control messages
 
@@ -119,7 +119,7 @@ the difinition of each message is shown in following subsection.
 
 ### PathPoint.msg
 
-`uint8 REFFERENCE=0`  
+`uint8 REFERENCE=0`  
 `uint8 FIXED=1`  
 `geometry_msgs/Pose pose`  
 `geometry_msgs/Twist twist`  

--- a/design/NamingConvention.md
+++ b/design/NamingConvention.md
@@ -18,18 +18,18 @@ Also, it is strongly recommended that the default topic names specified in sourc
 * All topics must be specified under following namespace in the node's private namespace. This allows users to easily understand which topics are inputs and outputs when they look at remapping in launch files for example.
   * `input`: subscribed topics
   * `output`: published topics 
-  * `debug`: published topics that are meant for debugging (e.g. for visulization)
+  * `debug`: published topics that are meant for debugging (e.g. for visualization)
 
-For example, if there is a node that subsribes pointcloud and filter it will voxel grid filter, the topics should be:
+For example, if there is a node that subscribes pointcloud and filter it will voxel grid filter, the topics should be:
 * ~input/points_original
 * ~output/points_filtered
 
 ### Remapped Topics
-The default topics of each nodes may be remapped to other topic names in launch file.
+The default topics of each node may be remapped to other topic names in launch file.
 In general, the topics should be published under namespaces of belonging modules in layered architecture for encapsulation.
 This allows the developers and users to easily understand where in the architecture topic is used.
 
-Some of other key topics are listed below:
+Some other key topics are listed below:
 ```
 /control/vehicle_cmd
 /perception/object_recognition/detection/objects

--- a/design/Overview.md
+++ b/design/Overview.md
@@ -20,8 +20,8 @@ The purpose of this proposal is to:
 
 By defining simplified interface between modules:
 - Internal processing in Autoware becomes more transparent
-- Joint developement of devlopers becomes easier due to less interdependency between modules
-- User's can easilty replace a module with their own software component(e.g. localization) just by "wrapping" their software to adjust to Autoware inteface
+- Joint development of developers becomes easier due to less interdependency between modules
+- User's can easily replace a module with their own software component(e.g. localization) just by "wrapping" their software to adjust to Autoware interface
 
 Note that the initial focus of this architecture design was solely on function of driving capability, and the following features are left as future work:
 * Real-time processing

--- a/design/Perception/ObjectRecognition/Detection/Detection.md
+++ b/design/Perception/ObjectRecognition/Detection/Detection.md
@@ -1,7 +1,7 @@
 Detection
 =====
 ## Use Cases and Requirements
-Detection in Object Recognition is required for usecases involved with obstacles:
+Detection in Object Recognition is required for use cases involved with obstacles:
 * Changing lane
 * Turning at intersection
 * Avoiding parked vehicles

--- a/design/Perception/ObjectRecognition/Prediction/Prediction.md
+++ b/design/Perception/ObjectRecognition/Prediction/Prediction.md
@@ -1,7 +1,7 @@
 Detection
 =====
 ## Use Cases and Requirements
-Prediction in Object Recognition is required for usecases involved with obstacles:
+Prediction in Object Recognition is required for use cases involved with obstacles:
 * Changing lane
 * Turning at intersection
 * Stopping at a crosswalk when pedestrians are walking
@@ -25,7 +25,7 @@ Prediction in Object Recognition estimate objects' intention. Intentions are rep
 
 ## Output
 
-| Output       | Data Type| Output Componenet | TF Frame | Topic|
+| Output       | Data Type| Output Component | TF Frame | Topic|
 |----|-|-|-|-|
 |Dynamic Objects|`autoware_perception_msgs::DynamicObjectArray`|Planning| `map`|/perception/object_recognition/objects|
 
@@ -42,4 +42,4 @@ Designated objects' property in autoware_perception_msgs::DynamicObject needs to
 
 | Property  | Definition |Data Type                                 | Parent Data Type|
 |-------------|--|-------------------------------------------|----|
-| predicted_path      | Predicted furuter paths for an object.|`autoware_perception_msgs::PredictedPath[]	`|`autoware_perception_msgs::State` |
+| predicted_path      | Predicted future paths for an object.|`autoware_perception_msgs::PredictedPath[]	`|`autoware_perception_msgs::State` |

--- a/design/Perception/ObjectRecognition/Tracking/Tracking.md
+++ b/design/Perception/ObjectRecognition/Tracking/Tracking.md
@@ -2,7 +2,7 @@ Detection
 =====
 
 ## Use Cases and Requirements
-Tracking in Object Recognition is required for usecases involved with obstacles:
+Tracking in Object Recognition is required for use cases involved with obstacles:
 * Changing lane
 * Turning at intersection
 * Avoiding parked vehicles

--- a/design/Perception/Perception.md
+++ b/design/Perception/Perception.md
@@ -15,7 +15,7 @@ Perception stack has 2 main roles.
 ## Use Cases
 Perception must provide enough information to support following use cases:
 
-| Usecase                                                 | Required output from  `Perception`                                                                                                              | How the output is used                                                                                                                                                                                                                                        |
+| Use case                                                | Required output from  `Perception`                                                                                                              | How the output is used                                                                                                                                                                                                                                        |
 | ------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | 1. Changing lane                                        | **Object Recognition-Prediction**:<br>-  Predicted paths of objects on target lane                                                                   | To decide `when` and `where` changing lane depending on objects' predicted paths. <br>`when`: which timing to trigger lane change  depending on obstacles position and velocity.  <br> `where`: where to go depending on objects' position and shape. |
 | 2. Turning at intersection                              | **Object Recognition- Prediction**:<br>- Predicted paths of objects at an intersection                                                               | To decide `when` turning at an intersection depending on objects' predicted path.  <br>`when`: which timing to turning depending on objects' future paths.                                                                                            |
@@ -76,7 +76,7 @@ This Perception stack consists of 2 separated modules and each module can be sub
 
 **Key points of the structure**
 
-- Interfaces are separated accoriding to the current algorithm level.
+- Interfaces are separated according to the current algorithm level.
 - Enable complex autonomous driving use cases by including information like objects' future movement.
 - Depends on technology development in the future, this structure might be changed (e.g. E2E).
 
@@ -125,7 +125,7 @@ Prediction component is responsible for clarifying the following objects' proper
 
 | Property       | Definition                             | Data Type                                    | Parent Data Type                  |
 | -------------- | -------------------------------------- | -------------------------------------------- | --------------------------------- |
-| predicted_path | Predicted furuter paths for an object. | `autoware_perception_msgs::PredictedPath[]   ` | `autoware_perception_msgs::State` |
+| predicted_path | Predicted future paths for an object.  | `autoware_perception_msgs::PredictedPath[]   ` | `autoware_perception_msgs::State` |
 
 Necessary information is defined in `autoware_perception_msg::DynamicObjectArray.msg` with layered msg structure.
 

--- a/design/Perception/TrafficLightRecognition/Classification/Classification.md
+++ b/design/Perception/TrafficLightRecognition/Classification/Classification.md
@@ -1,7 +1,7 @@
 Classification
 =====
 ## Use Cases and Requirements
-Classification in Traffic Light Recognition is required for usecases involved with traffic light:
+Classification in Traffic Light Recognition is required for use cases involved with traffic light:
 * Passing the intersection when traffic light is green
 * Stopping at the intersection when traffic signal is red
 

--- a/design/Perception/TrafficLightRecognition/Detection/Detection.md
+++ b/design/Perception/TrafficLightRecognition/Detection/Detection.md
@@ -2,7 +2,7 @@ Detection
 =====
 
 ## Use Cases and Requirements
-Detection in Traffic Light Recognition is required for usecases involved with traffic light:
+Detection in Traffic Light Recognition is required for use cases involved with traffic light:
 * Passing intersection when traffic signal is green
 * Stopping at intersection when traffic signal is red
 

--- a/design/Planning/DesignRationale.md
+++ b/design/Planning/DesignRationale.md
@@ -1,7 +1,7 @@
 # Planning Architecture Rationale
 
 ## Requirements for Planning
-Plannig architecture must be able to support any functions required to achieve the overall use case stated in [Overview](/Overview.md)
+Planning architecture must be able to support any functions required to achieve the overall use case stated in [Overview](/Overview.md)
 
 This includes: 
 - Calculates route that navigates to the desired goal
@@ -24,7 +24,7 @@ System overview of Boss is explained in this [paper](https://www.ri.cmu.edu/pub_
 The planner is decomposed into three layers: mission, behavior, and motion. Mission calculates the high-level global path from starting point to goal point, behavior makes tactical decisions such as lane change decisions and maneuvers at an intersection, and motion calculates low-level trajectory with consideration of kinematic model of the vehicle.
 
 **pros**
-* It is intuitive. Data flow is one-directional from mission to behavior to motion. Simlar approach was taken by different teams in the DARPA Urban Challenge.
+* It is intuitive. Data flow is one-directional from mission to behavior to motion. Similar approach was taken by different teams in the DARPA Urban Challenge.
 * It is suitable for OSS used world-wide since all traffic rule handling is done in the behavior layer, and developers only need to modify the behavior layer to support their local rules.
   
 **cons** 
@@ -63,7 +63,7 @@ Apollo kept updating the planning module at each version update. In version 5.0,
 ## Autoware Planning Architecture
 Considering pros and cons of different approaches, we have concluded to take the hybrid approach of Apollo and Boss. 
 
-We divided planning modules into scenarios just like Apollo, but into a more high-level scenario, such as LaneDriving and Parking. Apollo has smaller units of scenarios, such as intersection and traffic lights, but we expect that those scenarios may occur in parallel(e.g. intsection with traffic lights and crosswalks) and preparing combined-scenario modules would make scenario-selector too complex to be maintained. Instead, we made a scenario to be a more broad concept to keep the number of scenarios to be lower to keep scenario selector comprehensible. Currently, we only have LaneDriving and Parking, and we anticipate to have HighWay and InEmergency scenarios in the future. 
+We divided planning modules into scenarios just like Apollo, but into a more high-level scenario, such as LaneDriving and Parking. Apollo has smaller units of scenarios, such as intersection and traffic lights, but we expect that those scenarios may occur in parallel(e.g. intersection with traffic lights and crosswalks) and preparing combined-scenario modules would make scenario-selector too complex to be maintained. Instead, we made a scenario to be a more broad concept to keep the number of scenarios to be lower to keep scenario selector comprehensible. Currently, we only have LaneDriving and Parking, and we anticipate to have HighWay and InEmergency scenarios in the future. 
 
 More investigation is required to establish the definition of a “Scenario”, but the convention is that a new scenario must only be added whenever a different "paradigm" is needed for planning. 
 

--- a/design/Planning/LaneDriving/Behavior/BehaviorVelocityPlanner.md
+++ b/design/Planning/LaneDriving/Behavior/BehaviorVelocityPlanner.md
@@ -4,13 +4,13 @@ Behavior velocity planner is responsible for modifying velocity so that ego vehi
 
 ## Inputs
 topic name:  "path_with_lane_id"
-type: autoware_palnning_msgs::PathWithLaneId
+type: autoware_planning_msgs::PathWithLaneId
 frequency: 10Hz
 
 ## Outputs
 Behavior velocity planner should output path with velocity profile using following message type.
 topic name:  "path"
-type: autoware_palnning_msgs::Path
+type: autoware_planning_msgs::Path
 frequency: 10Hz
 
 ## Use Cases
@@ -30,7 +30,7 @@ Again, traffic rules might be different depending on country, and the requiremen
    * Ego vehicle must stop if a pedestrian is within stop area shown in the image.
    * Ego vehicle must stop if a pedestrian is expected to enter the stop area. (e.g. within 3 seconds)
    * Ego vehicle must slow down (e.g. to 5km/h) when there is a pedestrian in the deceleration area shown in the image.
-  **raitonale:** We don't want to make vehicle keep waiting for pedestrian to pass crosswalk completely. We want vehicle to start driving when pedestrian walks past the car.
+  **rationale:** We don't want to make vehicle keep waiting for pedestrian to pass crosswalk completely. We want vehicle to start driving when pedestrian walks past the car.
 
 ![Crosswalk](/design/img/Crosswalk.png)
 
@@ -56,7 +56,7 @@ The example node diagram of the behavior velocity planner is shown as the diagra
 ![BehaviorVelocityPlanner](/design/img/BehaviorVelocityPlanner.svg)
 
 The node consist of two steps.
-1. **Module Instance Update** From the given path, the planner will look up the HD Map to see if there are upcomming traffic rule features in the map. For each detected traffic rule features, respective scene module instance will be generated. Also, scene module instances from past features will be deleted. 
+1. **Module Instance Update** From the given path, the planner will look up the HD Map to see if there are upcoming traffic rule features in the map. For each detected traffic rule features, respective scene module instance will be generated. Also, scene module instances from past features will be deleted. 
 
 2. **Velocity Update** Actual modification of the velocity profile of the path happens in this step. Path message will be passed to each traffic rule scene modules, and each module will update velocity according to its traffic rule. Minimum value of all scene modules will become the final velocity profile.
 

--- a/design/Planning/LaneDriving/Behavior/LaneChangePlanner.md
+++ b/design/Planning/LaneDriving/Behavior/LaneChangePlanner.md
@@ -7,7 +7,7 @@ Input : topic "route" with type autoware_planning_msgs::Route
 
 ## Outputs
 topic name:  "path_with_lane_id"
-type: autoware_palnning_msgs::PathWithLaneId
+type: autoware_planning_msgs::PathWithLaneId
 frequency: 10Hz
 
 ## Assumptions

--- a/design/Planning/LaneDriving/LaneDrivingScenario.md
+++ b/design/Planning/LaneDriving/LaneDrivingScenario.md
@@ -46,11 +46,11 @@ It is decomposed into:
 
 
 ### MotionPlanner
-Motion planner is resposible for following functions:
+Motion planner is responsible for following functions:
 * Optimize the shape of trajectory with given lateral acceleration and jerk limit
   * Motion planner should not manipulate position of trajectory points from behavior planner outside given drivable area
-* Optimize the velocity of trajectory with given acceleraiton and jerk limit
-  * Motion planner is only allowed to decrease the speed profile given from behavior planner since all traffic rules(such as speedlimits) are considered in behavior planner. 
+* Optimize the velocity of trajectory with given acceleration and jerk limit
+  * Motion planner is only allowed to decrease the speed profile given from behavior planner since all traffic rules(such as speed limits) are considered in behavior planner. 
 * Interpolate trajectory points with enough resolution for Control
 
 #### Input

--- a/design/Planning/Parking/ParkingScenario.md
+++ b/design/Planning/Parking/ParkingScenario.md
@@ -1,5 +1,5 @@
 # Parking Scenario
-This scenario is meant to be used to plan manuevers to park vehicle in parking space. Compared to LaneDrivingScenario, this scenario has relative less constraints about the shape of trajectory.
+This scenario is meant to be used to plan maneuvers to park vehicle in parking space. Compared to LaneDrivingScenario, this scenario has relative fewer constraints about the shape of trajectory.
 
 ## Requirements:
 Lane Driving Scenario must satisfy the following use cases:
@@ -28,7 +28,7 @@ This gives spacial constraints to freespace planner.
 - Scenario: `autoware_planning_msgs::Scenario` <br> This is the message from scenario selector. All modules only run when Parking scenario is selected by this topic.
 
 #### Output
-* Costmap: `nav_msgs::OccupancyGrid.msg`<br> This contains spaces that can be used for trajectory planning. The grid is considered not passable(occupied) if it is outside of parking lot polygon specified map, and percepted objects lie on the grid.
+* Costmap: `nav_msgs::OccupancyGrid.msg`<br> This contains spaces that can be used for trajectory planning. The grid is considered not passable(occupied) if it is outside of parking lot polygon specified map, and perceived objects lie on the grid.
 
 ### Freespace Planner
 Freespace planner calculates trajectory that navigates vehicle to goal pose given by route. It must consider vehicle's kinematic model.

--- a/design/Planning/Planning.md
+++ b/design/Planning/Planning.md
@@ -20,7 +20,7 @@ Planning stack must satisfy following use cases:
 3. Driving along lane
 4. Following speed limit of lane
 5. Follow traffic light
-6. Follow yeild/stop signs
+6. Follow yield/stop signs
 7. Turning left/right at intersections
 8. Park vehicle at parking space (either reverse parking or forward first parking)
 
@@ -60,16 +60,16 @@ Planning stack must satisfy following use cases:
      * i.e. All points in planned trajectory has enough distance from other objects with ego vehicle's footprint taken into account
 
 8. **General requirements to trajectory**
-   * Planned trajectory must satisfy requirments from Control stack:
+   * Planned trajectory must satisfy requirements from Control stack:
      * Planned trajectory must have speed profile that satisfies given acceleration and jerk limits unless vehicle is under emergency e.g. when pedestrian suddenly jumps into driving lane or front vehicle suddenly stops.
      * Planned trajectory must be feasible by the given vehicle kinematic model
-     * Planned trajectory must to satisfy given lateral acceleration and jerk limit
+     * Planned trajectory must satisfy given lateral acceleration and jerk limit
      * Planned trajectory points within *n* [m] from ego vehicle should not change over time unless sudden steering or sudden acceleration is required to avoid collision with other vehicles.
        * *n*[m] = *velocity_of_ego_vehicle* * *configured_time_horizon*
 
 ## Input
 
-The table below summarizes the overal input into Planning stack:
+The table below summarizes the overall input into Planning stack:
 
 | Input                           | Topic Name(Data Type)                                                                                                   | Explanation                                                                                                                                                                                                                                                                                                         |
 | ------------------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -92,11 +92,11 @@ The table below summarizes the final output from Planning stack:
 # Design
 
 In order to achieve the requirements stated above, Planning stack is decomposed into the diagram below. 
-Each requirements are met in following modules:
+Each requirement is met in following modules:
 * Requirement 1: Mission calculates the overall route to reach goal from starting position 
-* Requirement 2-7: LaneDriving scanario plans trajectory along lanes in planned route
+* Requirement 2-7: LaneDriving scenario plans trajectory along lanes in planned route
 * Requirement 8: Parking scenario plans trajectory in free space to park into parking space 
-* Requirement 9: Both LaneDriving and Parking should output trajectory that sastifies the requirement
+* Requirement 9: Both LaneDriving and Parking should output trajectory that satisfies the requirement
 
 We have looked into different autonomous driving stacks and concluded that it is technically difficult to use unified planner to handle every possible situation. (See [here](/design/Planning/DesignRationale.md) for more details). Therefore, we have decided to set different planners in parallel dedicated for each use case, and let scenario selector to decide depending on situations. Currently, we have reference implementation with two scenarios, on-road planner and parking planner, but any scenarios (e.g. highway, in-emergency, etc.) can be added as needed. 
 
@@ -116,7 +116,7 @@ This module is responsible for calculating full route to goal, and therefore onl
 ### Input
 - current pose: `/tf` (map->base_link): <br> This is current pose in map frame calculated by Localization stack.
 - goal pose: geometry_msgs::PoseStamped <br> This is goal pose given from the Operator/Fleet Management Software
-- map: autoware_lanelet_msgs::MapBin <br> This is binary data of map from Map stack. This should include geometry information of each lanes to match input start/goal pose to corresponding lane, and lane connection information to calculate sequence of lanes to reach goal lane.
+- map: autoware_lanelet_msgs::MapBin <br> This is binary data of map from Map stack. This should include geometry information of each lane to match input start/goal pose to corresponding lane, and lane connection information to calculate sequence of lanes to reach goal lane.
 
 ### Output
 
@@ -130,7 +130,7 @@ route: `autoware_planning_msgs::Route` <br> Message type is described below. Rou
 ### Role
 
 The role of scenario selector is to select appropriate scenario planner depending on situation. For example, if current pose is within road, then scenario selector should choose on-road planner, and if vehicle is within parking lot, then scenario selector should choose parking scenario.
-Note that all trajectory calculated by each scenario module passes is collected by scenario selector, and scenario selector chooses which trajectory to be passed down to Control module. This ensures that trajectory from unselected scenario is not passed down to Control when scenario is changed even if there is a delay when scenario planner recieves notification that it is unselected by the scenario selector. 
+Note that all trajectory calculated by each scenario module passes is collected by scenario selector, and scenario selector chooses which trajectory to be passed down to Control module. This ensures that trajectory from unselected scenario is not passed down to Control when scenario is changed even if there is a delay when scenario planner receives notification that it is unselected by the scenario selector. 
 
 ### Input
 

--- a/design/Sensing/Sensing.md
+++ b/design/Sensing/Sensing.md
@@ -3,7 +3,7 @@ Sensing
 
 ## Overview 
 
-For autonomous driving, a vehicle needs to be aware of its state and surrouding environment. Sensing stack collects the environment information through various sensors and manipulates data appropriately to be used by other stacks.
+For autonomous driving, a vehicle needs to be aware of its state and surrounding environment. Sensing stack collects the environment information through various sensors and manipulates data appropriately to be used by other stacks.
 
 ![Sensing_overview](/design/img/SensingOverview.svg)
 
@@ -16,7 +16,7 @@ There are two main roles of Sensing stack:
   Raw data from sensors usually contains errors/noise due to hardware limitations. Sensing stack is responsible for removing such inaccuracies as much as possible before distributing sensor outputs to following stacks. Sensing stack may also do extra restructuring/formatting of data for so that there will be no duplicate data preprocessing done in different stacks.
 
 ## Use Cases
-The uses cases of Sensing stack are the followings:
+The use cases of Sensing stack are the followings:
 1. Estimating pose of the vehicle (Localization)
 2. Recognizing surrounding objects (Perception)
 3. Traffic light recognition (Perception)
@@ -30,7 +30,7 @@ For the use cases 1-3mentioned above, the actual computation is done in either [
 4. Sensing stack should convert all sensor specific data into ROS message for logging. (Use Case 4)
 5. In order to abstract sensor specification from other stacks, Sensing stack should provide sensor data as ROS message specified described in Output section.
 
-Since the architecture of [Localization](/Sensing/Sensing.md) stack and [Perception](/Perception/Perception.md) stack leaves choices of using different combinations of algorithms, Autoware does not set any requirements about input sensor configurations. It is the users responsibility to come up with appropriate sensor configuration to achieve the user's use cases.
+Since the architecture of [Localization](/Sensing/Sensing.md) stack and [Perception](/Perception/Perception.md) stack leaves choices of using different combinations of algorithms, Autoware does not set any requirements about input sensor configurations. It is the user's responsibility to come up with appropriate sensor configuration to achieve the user's use cases.
 
 As a reference, the recommended sensors from past experience with [Autoware.AI](http://autoware.ai/) is listed below:
 - LiDAR
@@ -55,10 +55,10 @@ The table below summarizes the output message for recommended sensors. More sens
 
 | Sensor | Topic (Data Type)                                                                                                                   | Explanation                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
 | ------ | ----------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| LiDAR  | `/sensing/lidar/pointcloud` <br> (`sensor_msgs::PointCloud2`)                                                                       | This contains 3D shape information of surrounding environement as a collection of rasterized points. It is usually used for map matching in Localization stack and object detection in Perception stack.                                                                                                                                                                                                                                                                         |
-| Camera | `/sensing/{camera_name}/image` <br>(`sensor_msgs::Image`) <br> `/sensing/{camera_name}/camera_info` <br>(`sensor_msgs::CameraInfo`) | Camera should provide both Image and CameraInfo topics. Image message contains 2D light intensity information (usually RGB). It is commonly used in Perception (Traffic Light Recognition, Object Recognition) and in Localization(Visual Odometry). By convention, image topic must be published in optical frame of the camera. <br> CameraInfo message contains camera intinsic paramters which is usually used to fuse pointcloud and image information in Perception stack. |
+| LiDAR  | `/sensing/lidar/pointcloud` <br> (`sensor_msgs::PointCloud2`)                                                                       | This contains 3D shape information of surrounding environment as a collection of rasterized points. It is usually used for map matching in Localization stack and object detection in Perception stack.                                                                                                                                                                                                                                                                          |
+| Camera | `/sensing/{camera_name}/image` <br>(`sensor_msgs::Image`) <br> `/sensing/{camera_name}/camera_info` <br>(`sensor_msgs::CameraInfo`) | Camera should provide both Image and CameraInfo topics. Image message contains 2D light intensity information (usually RGB). It is commonly used in Perception (Traffic Light Recognition, Object Recognition) and in Localization(Visual Odometry). By convention, image topic must be published in optical frame of the camera. <br> CameraInfo message contains camera intrinsic parameters which is usually used to fuse pointcloud and image information in Perception stack. |
 | GNSS   | `/sensing/gnss/gnss_pose`<br>(`geometry_msgs::PoseWithCovariance`)                                                                  | This contains absolute 3D pose on earth. The output should be converted into map frame to be used in Localization stack.                                                                                                                                                                                                                                                                                                                                                         |
-| IMU    | `/sensing/imu/imu_data`<br>(`sensor_msgs::Imu`)                                                                                     | This contains angular velocity and accelaration. The main use case is Twist estimation for Localization. The output data may also include estimated orientation as an option.                                                                                                                                                                                                                                                                                                    |
+| IMU    | `/sensing/imu/imu_data`<br>(`sensor_msgs::Imu`)                                                                                     | This contains angular velocity and acceleration. The main use case is Twist estimation for Localization. The output data may also include estimated orientation as an option.                                                                                                                                                                                                                                                                                                    |
 **rationale**: GNSS data is published as `geometry_msgs::PoseWithCovariance` instead of `sensor_msgs/NavSatFix`. `gometry_msgs` are also one of de facto message type, and PoseWithCovariance message essentially contains the same information and is more convenient for Localization stack(the most likely user of the data) since localization is done in Cartesian coordinate.
 
 # Design
@@ -69,7 +69,7 @@ In order to support the requirements, Sensing stack is decomposed as below. Depe
 
 ## Drivers
 
-Driver components act as interface between the hardware and ROS software, and they are responsible for converting sensor data into ROS messages. In order to support Requirement 4, drivers should focus on converting raw data to ROS message with minimal modification as much as possible. Ideally, the output message type of driver should the be same as the final output of Sensing stack, but exceptions are allowed in order to avoid loss of information during conversion or to achieve faster computation time in preprocessor.
+Driver components act as interface between the hardware and ROS software, and they are responsible for converting sensor data into ROS messages. In order to support Requirement 4, drivers should focus on converting raw data to ROS message with minimal modification as much as possible. Ideally, the output message type of driver should be the same as the final output of Sensing stack, but exceptions are allowed in order to avoid loss of information during conversion or to achieve faster computation time in preprocessor.
                                                                                                                                                            
 * **LiDAR driver**
   * Input: Raw data from LiDAR. Usually, it is list of range information with time stamp.
@@ -78,7 +78,7 @@ Driver components act as interface between the hardware and ROS software, and th
 * **Camera driver**
   * Input: 
     * Raw data from camera
-    * Calibration file of the camera that contains intrinsic camera paramter information
+    * Calibration file of the camera that contains intrinsic camera parameter information
   * Output: 
     * Image data in `sensor_msgs::Image`. 
     * Camera parameter information in`sensor_msgs::CameraInfo`. Although `sensor_msgs::CameraInfo` is not direct output from a camera, these information are published should be published with image since it contains essential information for image processing.
@@ -94,12 +94,12 @@ Driver components act as interface between the hardware and ROS software, and th
 
 ## Preprocessors
 
-Preprocessors are responsible for manipulating ROS message data to be more "useful" for following Autonomous Driving stacks. Actual implentation depends on how sensor data is used in other stacks. This may include:
+Preprocessors are responsible for manipulating ROS message data to be more "useful" for following Autonomous Driving stacks. Actual implementation depends on how sensor data is used in other stacks. This may include:
 - conversion of data format
 - removing unnecessary information
 - complementing necessary information
 - removing noise
-- imporving accuracies
+- improving accuracies
 
 Since the output of preprocessors will the final output of Sensing stack, it must follow the output ROS message type stated above.
 
@@ -131,12 +131,12 @@ Since the output of preprocessors will the final output of Sensing stack, it mus
 * **GNSS Preprocessor**
   *  Possible preprocessing functions: 
     * conversion of (latitude, longitude, altitude) to (x,y,z) in map coordinate
-    * (Optional) Deriving orientation using mutiple GNSS inputs
+    * (Optional) Deriving orientation using multiple GNSS inputs
     * (Optional) Filter out unreliable data
   * Input: `sensor_msgs::NavSatFix` message from driver.
   * Output: Pose in `geometry_msgs::PoseWithCovariance`. Unreliable data can also be filtered out based on satellite fix information. Each fields in the message should be calculated as following:
     * Pose: This must be projected into map frame from latitude and longitude information
-    * Orientation: This should be derived from calculating changes in position over time or byusing mutiple GNSS sensors on vehicle.
+    * Orientation: This should be derived from calculating changes in position over time or by using multiple GNSS sensors on vehicle.
     * Covariance: Covariance should reflect reliability of GNSS output. It may be relaying covariance from the input or reflect satellite fix status.
 
 * **IMU Preprocessor**  
@@ -144,4 +144,4 @@ Since the output of preprocessors will the final output of Sensing stack, it mus
     * Bias removal
     * orientation estimation
   * Input: `sensor_msgs::Imu` topic from IMU drivers.
-  * Ouptut: preprocessed `sensor_msgs::Imu` either relayed or modified from the input with functions stated above. Modification depends on hardware specification of IMU, and requirements from Localization algorithm.
+  * Output: preprocessed `sensor_msgs::Imu` either relayed or modified from the input with functions stated above. Modification depends on hardware specification of IMU, and requirements from Localization algorithm.

--- a/design/TF.md
+++ b/design/TF.md
@@ -38,7 +38,7 @@ In a typical setup the odom frame is computed based on an odometry source, such 
 
 The odom frame is useful as an accurate, short-term local reference, but drift makes it a poor frame for long-term reference.
 ```
-There are also discussions regarding the existance of odom frame in the following discussions:
+There are also discussions regarding the existence of odom frame in the following discussions:
 * https://discourse.ros.org/t/localization-architecture/8602/28
 + https://gitlab.com/autowarefoundation/autoware.auto/AutowareAuto/issues/292
 
@@ -51,7 +51,7 @@ Within the above discussions, the main reason for using odom frame is that:
 However, our view is that it doesn't mean that control is not affected by localization as long as trajectory following is done in the odom frame. For example, if a trajectory is calculated from the shape of the lane specified in an HD map, the localization result will be indirectly used when projecting trajectory into odom frame, and thus will be "blown off" when localization fails. Also, if any other map information is before trajectory calculation, such as shape optimization using map drivable area and velocity optimization using predicted trajectory of other vehicles which is derived from lane shape information, then localization failure will still affect the trajectory. Therefore, to make control independent of localization failure, we have to require all preceding calculation to not use map->odom transform. However, since trajectory following comes after planning in Autoware, it is almost impossible that map->odom isn't involved in trajectory calculation. Although it might be possible if Autoware plans like a human, who uses only route graph information from the map and obtain geometry information from perception, it is very unlikely that autonomous driving stack is capable of not using geometry information with safety ensured. 
 
 Therefore, regardless of any frame that control is done, it will still have effects of localization results. To make control not to jerk or do sudden steering at localization failure, we set the following requirements to Localization module:
-* localizatoin result must be continuous
+* localization result must be continuous
 * localization must detect localization failure and should not use the result to update vehicle pose.
 
 Additionally, Localization architecture assumes sequential Bayesian Filter, such as EKF and particle filter, to be used to integrate twist and pose. Since it can also integrate odometry information, it can update TF at high frequency. 
@@ -65,7 +65,7 @@ As a conclusion, we removed odom frame from this architecture proposal due to th
 3. If Localization module can satisfy the above conditions, there is no merit of using odom->base_link, and all modules should use map->base_link whenever they need a world-fixed frame.
 
 ### Possible Concerns
-* Above argument focusses on replacing map->odom->base_link with map->base_link, but doesn't prove that map->base_link is better. If we set odom->base_link, wouldn't we have more options of frames?
+* Above argument focuses on replacing map->odom->base_link with map->base_link, but doesn't prove that map->base_link is better. If we set odom->base_link, wouldn't we have more options of frames?
   * Once we split map->base_link into map->odom and odom->base_link, we loose velocity information and uncertainty(covariance) information between them. We can expect more robustness if we integrate all information(odometry and output of multiple localization) at once.
   * If it is split into map->odom and odom->base_link, we have to wait for both transforms to obtain map->base_link transform. It is easier to estimate delay time if it is combined into one TF.
   * We think that creating odom frame using current architecture is possible. However, we should first discuss if we have any component that wants to use odom->base_link. We anticipate that it might be needed when we design safety architecture, which is out-of-scope in this proposal, but it must be added after all safety analysis is done. As stated above, using odom frame in Control module is not enough for safety.

--- a/design/Vehicle/Vehicle.md
+++ b/design/Vehicle/Vehicle.md
@@ -77,9 +77,9 @@ The input to Vehicle stack:
 
 The detailed contents in Vehicle Command are as follows.
 
-| Input                  | Data Type        | Explanation                            |
+| Input                   | Data Type        | Explanation                            |
 | ----------------------- | ---------------- | -----------                            |
-| Velocity                | std_msgs/Float64 | Target veocity [m/s]                   |
+| Velocity                | std_msgs/Float64 | Target velocity [m/s]                  |
 | Acceleration            | std_msgs/Float64 | Target acceleration [m/s2]             |
 | Steering angle          | std_msgs/Float64 | Target steering angle [rad]            |
 | Steering angle velocity | std_msgs/Float64 | Target steering angle velocity [rad/s] |


### PR DESCRIPTION
Fix typo in design documents.
Please merge this with the following pull request simultaneously for `PathPoint.msg`.
https://github.com/tier4/AutowareArchitectureProposal.iv/pull/433