### PR TITLE
Add individual_params to .repos

### DIFF
--- a/autoware.proj.repos
+++ b/autoware.proj.repos
@@ -8,6 +8,10 @@ repositories:
     type: git
     url: https://github.com/tier4/autoware_launcher.iv.universe.git
     version: ros2
+  autoware/individual_params:
+    type: git
+    url: https://github.com/tier4/autoware_individual_params.git
+    version: main
   # description
   description/sensor/sensor_description:
     type: git


### PR DESCRIPTION
Related PR: https://github.com/tier4/autoware_launcher.iv.universe/pull/100

Add individual_params package to `.repos` that is removed in https://github.com/tier4/autoware_launcher.iv.universe/pull/101.