### PR TITLE
🐞 fix(repo): branch changed to ros1

### DIFF
--- a/autoware.proj.repos
+++ b/autoware.proj.repos
@@ -3,11 +3,11 @@ repositories:
   autoware/AutowareArchitectureProposal.iv:
     type: git
     url: git@github.com:tier4/AutowareArchitectureProposal.iv.git
-    version: master 
+    version: ros1 
   autoware/launcher:
     type: git
     url: git@github.com:tier4/autoware_launcher.iv.universe.git
-    version: master 
+    version: ros1 
   # description
   description/sensor/sensor_description:
     type: git


### PR DESCRIPTION
## PR Type

<!-- Select one and remove others. If an appropriate one is not listed, please write by yourself. -->
- Bug Fix

## Description

The `master` branch changed from `ROS1` to `ROS2` but repo keeps [master](https://github.com/tier4/AutowareArchitectureProposal.proj/blob/ros1/autoware.proj.repos#L6) branch, this makes error when `vcs import ros1 repo`

## Review Procedure

<!-- Explain how to review this PR. -->

This fix changes branch name from `master` to `ros1`

## CI Checks

- **vcs import**: Required to pass before the merge.
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
